### PR TITLE
Quotes on yml values that include colons

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
 email: admin@neverworkintheory.org
-permalink: /:year/:month/:day/:title.html
-url: http://neverworkintheory.org
+permalink: "/:year/:month/:day/:title.html"
+url: "http://neverworkintheory.org"
 exclude: [wordpress.xml, extract.py]

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <link href="{{page.root}}/css/bootstrap/bootstrap.css" rel="stylesheet" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <link href="{{page.root}}/css/bootstrap/bootstrap-responsive.css" rel="stylesheet" />
-<link rel="alternate" type="application/rss+xml" title="It Will Never Work In Theory Blog" href="{{page.root}}/feed.xml"/>
+<link rel="alternate" type="application/rss+xml" title="It Will Never Work In Theory Blog" href="{{site.url}}/feed.xml"/>
 <meta http-equiv="last-modified" content="{{site.time}}" />
 <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
 <!--[if lt IE 9]>


### PR DESCRIPTION
Trying to fix the remote page build error by adding quotes on yml values that have colons.
