### PR TITLE
Fix broken links to other NWIT pages.

### DIFF
--- a/_posts/2014-01-29-stefik-siebert-syntax.html
+++ b/_posts/2014-01-29-stefik-siebert-syntax.html
@@ -35,10 +35,10 @@ categories: [Controlled Experiments, Programming Languages]
 
 <p>
   This paper is a follow-on to one we
-  <a href="./2011-10-24-an-empirical-comparison-of-the-accuracy-rates-of-novices-using-the-quorum-perl-and-randomo-programming-languages.html">wrote
+  <a href="http://neverworkintheory.org/2011/10/24/an-empirical-comparison-of-the-accuracy-rates-of-novices-using-the-quorum-perl-and-randomo-programming-languages.html">wrote
   about</a> a couple of years ago that generated a lot of comments,
   many of them unpleasant.
-  Stefik <a href="./2011-10-27-author-response-quorum-vs-perl-vs-randomo-novice-accuracy-rates.html">responded</a>
+  Stefik <a href="http://neverworkintheory.org/2011/10/27/author-response-quorum-vs-perl-vs-randomo-novice-accuracy-rates.html">responded</a>
   then, and he and Siebert have now followed up with several more
   studies that show:
 </p>


### PR DESCRIPTION
The relative links were not working, because "./" is at `/2014/01/29`. This change uses absolute links to other pages on the neverworkintheory site.
