### PR TITLE
fixes disappearing navigation on smaller screens

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,11 +1,17 @@
 <nav class="navbar navbar-default">
   <div class="container-fluid">
     <div class="navbar-header">
+    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse" aria-expanded="false">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
       <a href="{{ site.url }}" class="pull-left">
         <img class="navbar-logo" src="{{ site.root }}/assets/img/scales.svg" alt="Never Work in Theory logo" />
       </a>
     </div>
-    <div class="collapse navbar-collapse">
+    <div class="collapse navbar-collapse" id="navbar-collapse">
       <ul class="nav navbar-nav">
 	<li><a href="{{site.url}}/about.html">About</a></li>
 	<li><a href="{{site.url}}/guidelines.html">Guidelines</a></li>


### PR DESCRIPTION
Currently the navigation vanishes on screens below a certain resolution. This fix adds in the standard bootstrap "hamburger" menu when viewed on smaller screens. It is taken directly from the bootstrap examples
