### PR TITLE
Update 2014-01-29-stefik-siebert-syntax.html

### DIFF
--- a/_posts/2014/2014-01-29-stefik-siebert-syntax.html
+++ b/_posts/2014/2014-01-29-stefik-siebert-syntax.html
@@ -75,8 +75,6 @@ categories: ["Controlled Experiments", "Programming Languages"]
   number of sermons on the beauty of functional programming.
 </p>
 
-<p><em>Note that this paper is available
-from <a href="http://web.cs.unlv.edu/stefika/Papers.php">the author's
-website</a>, but only after a redirect to an ACM website that makes
-you wait a few seconds for another redirect, because that's what the
-ACM does to encourage people to take research seriously.</em></p>
+<p><em>Note that this paper is not directly available
+from <a href="http://web.cs.unlv.edu/stefika/research.html">the author's
+website</a>, but can be found <a href="https://www.vidarholen.net/~vidar/An_Empirical_Investigation_into_Programming_Language_Syntax.pdf">hosted here as a PDF</a>.</em></p>


### PR DESCRIPTION
I regularly reference this page and the links had become outdated. Thought I'd fix them up. This corrects the link to the authors page and adds a direct PDF link for the paper