### PR TITLE
add alkhabaz-2021-mongodb-homework

### DIFF
--- a/_posts/2021/2021-10-10-mongodb-homework
+++ b/_posts/2021/2021-10-10-mongodb-homework
@@ -1,0 +1,25 @@
+---
+layout: post
+author: Donny Winston
+title: "Insights from Student Solutions to MongoDB Homework Problems"
+date: 2021-10-10
+categories: ["Databases", "Computing Education", "Novices"]
+---
+<div class="review">
+  <p>
+    <cite>Alkhabaz2021</cite> tries to determine what concepts are difficult for students when learning MongoDB, and what common errors students make when first learning to query a MongoDB database. I came away not quite understanding the authors' conclusions, but I did encounter two observations that surprised me:
+    <ul>
+    <li>3.5% of student submissions "were omitted from this study, because they had a common error where students copied JavaScript code from online sources, causing the interpreter to fail due to an unexpected unicode character." That seems like a lot to me, and highlights the prevalence of "copy-and-paste" programming even in early computing education.</li>
+    <li>47% of all submissions resulted in "incorrect result set" (versus "mongodb error", "javascript error", or "correct"), that is a "silent" error. In retrospect, this should not have surprised me as much as it did. Others such as Rich Hickey ([talk](https://www.youtube.com/watch?v=2V1FtfBDsLU), [transcript](https://github.com/matthiasn/talk-transcripts/blob/9f33e07ac392106bccc6206d5d69efe3380c306a/Hickey_Rich/EffectivePrograms.md), [slide](https://github.com/matthiasn/talk-transcripts/blob/9f33e07ac392106bccc6206d5d69efe3380c306a/Hickey_Rich/EffectivePrograms/00.27.19.png)) have insisted that most of problems in the practice of programming are above the "language model complexity" level, such as dealing with misconceptions. </li>
+    </ul>
+  </p>
+</div>
+<p id="Alkhabaz2021" class="bib"><cite>Alkhabaz2021</cite>
+  Ridha Alkhabaz and Seth Poulsen and Mei Chen and Abdussalam Alawini:
+  "<a href="https://doi.org/10.1145/3430665.3456308">Insights from Student Solutions to MongoDB Homework Problems</a>".
+  <em>ACM</em>, 2021,
+  <a class="doi" href="https://doi.org/10.1145/3430665.3456308">10.1145/3430665.3456308</a>.
+</p>
+<blockquote class="abstract">
+We analyze submissions for homework assignments of 527 students in an upper-level database course offered at the University of Illinois at Urbana-Champaign. The ability to query databases is becoming a crucial skill for technology professionals and academics. Although we observe a large demand for teaching database skills, there is little research on database education. Also, despite the industry's continued demand for NoSQL databases, we have virtually no research on the matter of how students learn NoSQL databases, such as MongoDB. In this paper, we offer an in-depth analysis of errors committed by students working on MongoDB homework assignments over the course of two semesters. We show that as students use more advanced MongoDB operators, they make more Reference errors. Additionally, when students face a new functionality of MongoDB operators, such as \texttt{\$group} operator, they usually take time to understand it but do not make the same errors again in later problems. Finally, our analysis suggests that students struggle with advanced concepts for a comparable amount of time. Our results suggest that instructors should allocate more time and effort for the discussed topics in our paper.
+</blockquote>

--- a/tex/nwit.bib
+++ b/tex/nwit.bib
@@ -100,6 +100,18 @@
   reviewed = {/2021/08/11/cheating-death-survival-analysis-of-python-projects.html}
 }
 
+@inproceedings{Alkhabaz2021,
+  doi = {10.1145/3430665.3456308},
+  url = {https://doi.org/10.1145/3430665.3456308},
+  year = {2021},
+  month = jun,
+  publisher = {{ACM}},
+  author = {Ridha Alkhabaz and Seth Poulsen and Mei Chen and Abdussalam Alawini},
+  title = {Insights from Student Solutions to {MongoDB} Homework Problems},
+  booktitle = iticse,
+  abstract = {We analyze submissions for homework assignments of 527 students in an upper-level database course offered at the University of Illinois at Urbana-Champaign. The ability to query databases is becoming a crucial skill for technology professionals and academics. Although we observe a large demand for teaching database skills, there is little research on database education. Also, despite the industry's continued demand for NoSQL databases, we have virtually no research on the matter of how students learn NoSQL databases, such as MongoDB. In this paper, we offer an in-depth analysis of errors committed by students working on MongoDB homework assignments over the course of two semesters. We show that as students use more advanced MongoDB operators, they make more Reference errors. Additionally, when students face a new functionality of MongoDB operators, such as \texttt{\$group} operator, they usually take time to understand it but do not make the same errors again in later problems. Finally, our analysis suggests that students struggle with advanced concepts for a comparable amount of time. Our results suggest that instructors should allocate more time and effort for the discussed topics in our paper.}
+}
+
 @inproceedings{Almeida2017,
   doi = {10.1109/icpc.2017.7},
   url = {https://doi.org/10.1109/icpc.2017.7},

--- a/tex/todo.bib
+++ b/tex/todo.bib
@@ -14,18 +14,6 @@
   abstract = {Software smells indicate design or code issues that might degrade the evolution and maintenance of software systems. Detecting and identifying these issues are challenging tasks. This paper explores, identifies, and analyzes the existing software smell detection techniques at design and code levels. We carried out a systematic literature review (SLR) to identify and collect 145 primary studies related to smell detection in software design and code. Based on these studies, we address several questions related to the analysis of the existing smell detection techniques in terms of abstraction level (design or code), targeted smells, used metrics, implementation, and validation. Our analysis identified several detection techniques categories. We observed that 57\% of the studies did not use any performance measures, 41\% of them omitted details on the targeted programing language, and the detection techniques were not validated in 14\% of these studies. With respect to the abstraction level, only 18\% of the studies addressed bad smell detection at the design level. This low coverage urges for more focus on bad smell detection at the design level to handle them at early stages. Finally, our SLR brings to the attention of the research community several opportunities for future research.}
 }
 
-@inproceedings{Alkhabaz2021,
-  doi = {10.1145/3430665.3456308},
-  url = {https://doi.org/10.1145/3430665.3456308},
-  year = {2021},
-  month = jun,
-  publisher = {{ACM}},
-  author = {Ridha Alkhabaz and Seth Poulsen and Mei Chen and Abdussalam Alawini},
-  title = {Insights from Student Solutions to {MongoDB} Homework Problems},
-  booktitle = iticse,
-  abstract = {We analyze submissions for homework assignments of 527 students in an upper-level database course offered at the University of Illinois at Urbana-Champaign. The ability to query databases is becoming a crucial skill for technology professionals and academics. Although we observe a large demand for teaching database skills, there is little research on database education. Also, despite the industry's continued demand for NoSQL databases, we have virtually no research on the matter of how students learn NoSQL databases, such as MongoDB. In this paper, we offer an in-depth analysis of errors committed by students working on MongoDB homework assignments over the course of two semesters. We show that as students use more advanced MongoDB operators, they make more Reference errors. Additionally, when students face a new functionality of MongoDB operators, such as \texttt{\$group} operator, they usually take time to understand it but do not make the same errors again in later problems. Finally, our analysis suggests that students struggle with advanced concepts for a comparable amount of time. Our results suggest that instructors should allocate more time and effort for the discussed topics in our paper.}
-}
-
 @article{AlSubaihin2021,
   doi = {10.1109/tse.2019.2891715},
   url = {https://doi.org/10.1109/tse.2019.2891715},


### PR DESCRIPTION
@gvwilson Ready for review. Please use <https://donnywinston.com> in the acknowledgements.

`_template.html` didn't have `<p class="bib"></p>` or `<blockquote class="abstract"></blockquote>` sections below `<div class="review"></div>`, so I just copy-pasted from a recent post and tried to guess the format. It seemed from 5 and 6 of <https://neverworkintheory.org/contributing/>'s "When filling in the HTML template:" list that I'm supposed to do something like that, but perhaps these sections are automatically built by CI at this point? I don't know.
