### PR TITLE
Update links in 2011-08-24 Michael Feathers review

### DIFF
--- a/_posts/2011/2011-08-24-what-michael-feathers-thinks-you-should-read.html
+++ b/_posts/2011/2011-08-24-what-michael-feathers-thinks-you-should-read.html
@@ -12,21 +12,21 @@ categories: ["Noticed"]
     of <a href="http://www.amazon.com/Working-Effectively-Legacy-Michael-Feathers/dp/0131177052">one
     of our favorite books on programming</a>. In February 2009, he
     posted a list of
-    <a href="http://blog.objectmentor.com/articles/2009/02/26/10-papers-every-programmer-should-read-at-least-twice">ten
+    <a href="https://michaelfeathers.silvrback.com/10-papers-every-developer-should-read-at-least-twice">ten
     papers that every programmer should read at least twice</a>:
   </p>
 </div>
 <ol>
   <li><a href="http://sunnyday.mit.edu/16.355/parnas-criteria.html">On the criteria to be used in decomposing systems into modules</a>: David Parnas</li>
-  <li><a href="http://research.sun.com/techrep/1994/abstract-29.html">A Note On Distributed Computing</a>: Jim Waldo, Geoff Wyant, Ann Wollrath, Sam Kendall</li>
+  <li><a href="https://scholar.harvard.edu/files/waldo/files/waldo-94.pdf">A Note On Distributed Computing</a>: Jim Waldo, Geoff Wyant, Ann Wollrath, Sam Kendall</li>
   <li><a href="http://portal.acm.org/citation.cfm?id=365257">The Next 700 Programming Languages</a>: P. J. Landin</li>
   <li><a href="http://portal.acm.org/citation.cfm?id=359579">Can Programming Be Liberated from the von Neumann Style?</a>: John Backus</li>
-  <li><a href="http://cm.bell-labs.com/who/ken/trust.html">Reflections on Trusting Trust</a>: Ken Thompson</li>
+  <li><a href="https://dl.acm.org/doi/10.1145/358198.358210">Reflections on Trusting Trust</a>: Ken Thompson</li>
   <li><a href="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.50.6083">Lisp: Good News, Bad News, How to Win Big</a>: Richard Gabriel</li>
   <li><a href="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.29.363">An experimental evaluation of the assumption of independence in multiversion programming</a>: John Knight and Nancy Leveson</li>
   <li><a href="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.50.7565">Arguments and Results</a>: James Noble</li>
   <li><a href="http://c2.com/doc/oopsla89/paper.html">A Laboratory For Teaching Object-Oriented Thinking</a>: Kent Beck, Ward Cunningham</li>
-  <li><a href="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.31.562">Programming as an Experience: the inspiration for Self</a>: David Ungar, Randall B. Smith</li>
+  <li><a href="https://www.researchgate.net/publication/2467120_Programming_as_an_Experience_The_Inspiration_for_Self">Programming as an Experience: the inspiration for Self</a>: David Ungar, Randall B. Smith</li>
 </ol>
 <p>
   His reasons for picking these papers over tens of thousands of


### PR DESCRIPTION
Fix broken links to:
- "Ten papers that every programmer should read at least twice"
- "A Note On Distributed Computing"
- "Reflections on Trusting Trust"

Found a better link to "Programming as an Experience: the inspiration
for Self".  The link from the citeseerx site has the pages in reverse
Order.  Replaced link with one from reseachgate.