### PR TITLE
Fix #203: Make Atom XML headers use absolute URLs

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -4,8 +4,8 @@ layout: null
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
  <title>{{ site.title | xml_escape }}</title>
- <link href="{{ '/atom.xml' | relative_url }}" rel="self"/>
- <link href="{{ '/' | relative_url }}"/>
+ <link href="{{ '/atom.xml' | absolute_url }}" rel="self"/>
+ <link href="{{ '/' | absolute_url }}"/>
  <updated>{{ site.time | date_to_xmlschema }}</updated>
  <id>{{ site.url }}</id>
  <author>
@@ -15,7 +15,7 @@ layout: null
  {% for post in site.posts limit:20 %}
  <entry>
    <title>{{ post.title | xml_escape }}</title>
-   <link href="{{ post.url | relative_url }}"/>
+   <link href="{{ post.url | absolute_url }}"/>
    <updated>{{ post.date | date_to_xmlschema }}</updated>
    <id>{{ site.url }}{{ post.id }}</id>
    <content type="html">{{ post.content | xml_escape }}</content>


### PR DESCRIPTION
This is the first version of fixing the XML header (addressing issue #203). It seems like it may be the cleanest way to do it, so I'll only make the base url version if requested. Here is a snapshot of the difference in the generated source:

```diff
<feed xmlns="http://www.w3.org/2005/Atom">
 <title>It Will Never Work in Theory</title>
- <link href="/atom.xml" rel="self"/>
+ <link href="http://localhost:4000/atom.xml" rel="self"/>
- <link href="/"/>
+ <link href="http://localhost:4000/"/>
 <updated>2023-04-28T19:31:04+00:00</updated>
 <id>https://neverworkintheory.org</id>
 <author>
   <name>Greg Wilson</name>
   <email>gvwilson@third-bit.com</email>
 </author>

 <entry>
   <title>A Few More to Close</title>
-   <link href="/2023/04/27/a-few-more-to-close.html"/>
+   <link href="http://localhost:4000/2023/04/27/a-few-more-to-close.html"/>
   <updated>2023-04-27T00:00:00+00:00</updated>
   <id>https://neverworkintheory.org/2023/04/27/a-few-more-to-close</id>
```

The benefit of using base url might be that it will always be off of neverworkintheory.org rather than a local build url -- let me know if you prefer that. 